### PR TITLE
powermizer.lua: Fix powermizer not working, silence the which test.

### DIFF
--- a/powermizer/powermizer.lua
+++ b/powermizer/powermizer.lua
@@ -51,9 +51,9 @@ if (test == 0 or test == true) then
     function switch(name, paused)
         -- If it's nil it's because of the "shutdown" event.
         if (paused == true or paused == nil) then
-            os.execute("nvidia-settings -q -a " .. gpu .. "/GPUPowerMizerMode=0 > /dev/null")
+            os.execute("nvidia-settings -a " .. gpu .. "/GPUPowerMizerMode=0 > /dev/null")
         else
-            os.execute("nvidia-settings -q -a " .. gpu .. "/GPUPowerMizerMode=1 > /dev/null")
+            os.execute("nvidia-settings -a " .. gpu .. "/GPUPowerMizerMode=1 > /dev/null")
         end
     end
 

--- a/powermizer/powermizer.lua
+++ b/powermizer/powermizer.lua
@@ -28,7 +28,7 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     https://www.gnu.org/licenses/gpl-2.0.html
 --]]
-local test = os.execute("which nvidia-settings &> /dev/null")
+local test = os.execute("which nvidia-settings > /dev/null")
 if (test == 0 or test == true) then
     local gpu = mp.get_opt("powermizer-gpu")
     if (gpu ~= nil) then
@@ -51,9 +51,9 @@ if (test == 0 or test == true) then
     function switch(name, paused)
         -- If it's nil it's because of the "shutdown" event.
         if (paused == true or paused == nil) then
-            os.execute("nvidia-settings -a " .. gpu .. "/GPUPowerMizerMode=0 > /dev/null")
-        elseif (paused == false)
-            os.execute("nvidia-settings -a " .. gpu .. "/GPUPowerMizerMode=1 > /dev/null")
+            os.execute("nvidia-settings -q -a " .. gpu .. "/GPUPowerMizerMode=0 > /dev/null")
+        else
+            os.execute("nvidia-settings -q -a " .. gpu .. "/GPUPowerMizerMode=1 > /dev/null")
         end
     end
 


### PR DESCRIPTION
There was a `then` missing in the `elseif` statement. Since besides `true`, `false` and `nil` there are no other values possible I replaced the `elseif` with an `else`, which also fixes to problem.

I also replaced the `&>` in the `which nvidia-settings` command, because `&>` prints the path to the terminal, even when running mpv in really-quiet mode.
